### PR TITLE
redesign of resuming chat

### DIFF
--- a/pages/02_run.py
+++ b/pages/02_run.py
@@ -72,6 +72,8 @@ def display_graph(placeholder, active_node=None):
   
 warnings.filterwarnings('ignore')  
 
+
+
 # Callback function to print messages
 # based on https://github.com/microsoft/autogen/issues/478
 def print_messages_callback(recipient, messages, sender, config):     
@@ -86,15 +88,17 @@ def print_messages_callback(recipient, messages, sender, config):
     return False, None  # required to ensure the agent communication flow continues
 
 def display_messages_history(messages):
-    with st.container(border=True):
-        st.write("Chat History:")
+    with st.expander(f"Chat history ({len(messages)})",expanded=False):
+        # st.write("Chat History:")
         # Output the final chat history showing the original 4 messages and resumed messages
         for i, message in enumerate(messages):
             try:
                 sender = message["name"]
             except:
                 sender = "AdminX"    
-            with st.expander(f"{i+1}: From {sender}", expanded=False):
+            # with st.expander(f"{i+1}: From {sender}", expanded=False):
+            with st.container(border=True):
+                st.caption(f"{i+1}: {sender}")
                 st.write(message["content"])
 
     return False, None  # required to ensure the agent communication flow continues
@@ -131,6 +135,15 @@ if 'messages' not in st.session_state:
 if 'first_query' not in st.session_state:  
     st.session_state.first_query = True  
 
+# handling text based on the first query
+if st.session_state.first_query:
+    button_label = "🏃‍♂️ Run Agents"
+    task_label = "Enter your task:"
+    task_example = "What are the 10 leading GitHub repositories on llm for the legal domain?"
+else:
+    button_label = "🏃‍♂️ Continue Agents' flow with the input/feedback"
+    task_label = "Enter your input/feedback to resume agentic workflow:"
+    task_example = ""
 
 # # TODO: REMOVE
 # import json
@@ -288,16 +301,11 @@ if (st.session_state.able_to_run):
     if st.session_state.messages:
         display_messages_history(st.session_state.messages)
 
-    task = st.text_input("Enter your task:", "What are the 10 leading GitHub repositories on llm for the legal domain?")  
+    task = st.text_input(task_label, task_example)  
     with st.container(border=True):
         placeholder = st.empty()
         display_graph(placeholder, active_node="Admin")
 
-    # handling the button label based on the first query
-    if st.session_state.first_query:
-        button_label = "Run Agents"
-    else:
-        button_label = "Continue Agents' flow with new task"
 
     if st.button(button_label, type="primary"):
         
@@ -306,6 +314,13 @@ if (st.session_state.able_to_run):
         with st.spinner("Running agents..."):
             chat_result = run(manager=manager, user_proxy=user_proxy, task=task)
 
-        st.write("Done! But you can follow-up the conversation with a new task.")
+        if st.button("Give another task (resume)?", type="primary"):
+            st.rerun()
+
+        if st.button("Clear History"):  
+            st.session_state.messages = []  
+            st.session_state.first_query = True  
+            st.write("Chat history cleared.")
+            st.rerun()
         
 


### PR DESCRIPTION
This pull request includes changes to the `pages/02_run.py` file to improve the user interface and chat history display. The most important changes include modifying the `display_graph` function to add extra spacing, changing the `display_messages_history` function to use a collapsible section for chat history, handling text based on the first query, modifying the `run` function to change the task input label and example, and adding buttons to give another task or clear chat history.

Changes to improve the user interface:

* [`pages/02_run.py`](diffhunk://#diff-eaca9106caf3a75ad3e559da3b8fc1c7ad16b0bfbe87654acede2182ed718cd4R75-R76): Added extra spacing in the `display_graph` function to improve readability.
* [`pages/02_run.py`](diffhunk://#diff-eaca9106caf3a75ad3e559da3b8fc1c7ad16b0bfbe87654acede2182ed718cd4L89-R101): Changed the `display_messages_history` function to use a collapsible section for chat history, and changed the message display to use a container with a caption instead of an expander.
* [`pages/02_run.py`](diffhunk://#diff-eaca9106caf3a75ad3e559da3b8fc1c7ad16b0bfbe87654acede2182ed718cd4R138-R146): Added handling of text based on whether it's the first query or not, changing the button label and task input label and example accordingly in the main script.

Changes to the `run` function:

* [`pages/02_run.py`](diffhunk://#diff-eaca9106caf3a75ad3e559da3b8fc1c7ad16b0bfbe87654acede2182ed718cd4L291-L300): Modified the `run` function to use the previously defined task label and example in the task input, and removed the previous handling of the button label.
* [`pages/02_run.py`](diffhunk://#diff-eaca9106caf3a75ad3e559da3b8fc1c7ad16b0bfbe87654acede2182ed718cd4L309-R324): Added buttons to give another task (which reruns the script) or clear the chat history (which also reruns the script after clearing the chat history and setting the first query flag to true).