### PR TITLE
FIX - allowed transitions - remove self-reference

### DIFF
--- a/pages/01_setup_transitions.py
+++ b/pages/01_setup_transitions.py
@@ -150,7 +150,9 @@ if st.session_state.able_to_run:
         with st.expander("Setup allowed transitions", expanded=True):
             # st.write("Setup allowed transitions:")
             for agent in st.session_state.saved_agents:
-                agents_transitions[agent["name"]] = st.multiselect(agent["name"], _agents_dict.keys(), _agents_dict.keys())
+                
+                _allowed_keys = [_a for _a in _agents_dict.keys() if _a != agent["name"]]
+                agents_transitions[agent["name"]] = st.multiselect(agent["name"], _allowed_keys, _allowed_keys)
 
             # st.write(agents_transitions)
 


### PR DESCRIPTION
This pull request includes a change to the function in `pages/01_setup_transitions.py` to improve the setup of allowed transitions by excluding the current agent's name from the list of selectable agents.

Improvements to transition setup:

* [`pages/01_setup_transitions.py`](diffhunk://#diff-90d3cdc07fd84989ba0496b663ec0bea815e9a7ecbb67187431d1b42c54da7c3L153-R155): Modified the function to exclude the current agent's name from the `_allowed_keys` list when setting up allowed transitions using `st.multiselect`.